### PR TITLE
Add runnable static chat UI prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,19 @@ Performance:
   - Data loader produces forward dates after `as_of` when a tiny cache exists.
   - Cumulative product math verified on simple series.
 
+## Chat UI Prototype (static, runnable)
+
+A lightweight, dependency-free prototype of the login → chat → profile flow lives in `web/`.
+
+**How to run**
+
+- Open `web/index.html` directly in your browser, or serve the folder locally (e.g., `python -m http.server 8000` from the repo root and navigate to `http://localhost:8000/web/`).
+- The prototype includes:
+  - Login card with email/password and a stubbed “Forgot password?” link.
+  - Chat workspace with sidebar conversations, active chat header, message list, and composer.
+  - Profile page with editable fields, preference toggles, and a “Back to chat” action.
+  - Mobile-friendly tweaks (sidebar collapses, back button appears) for narrow screens.
+
 ### Test Principles Used
 - Determinism: synthetic data uses fixed seeds; pandas operations use explicit sorting.
 - Leakage safety: all agent tests filter to `date <= as_of`.

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,155 @@
+const views = {
+  login: document.getElementById('login'),
+  chat: document.getElementById('chat'),
+  profile: document.getElementById('profile'),
+};
+
+const chatListEl = document.getElementById('chat-list');
+const messageListEl = document.getElementById('message-list');
+const chatNameEl = document.getElementById('chat-name');
+const chatStatusEl = document.getElementById('chat-status');
+
+const chats = [
+  {
+    id: 'general',
+    name: 'General Chat',
+    status: 'Active now',
+    preview: 'Hey, how can I help?',
+    messages: [
+      { from: 'them', text: 'Hey, how can I help?', time: '11:00' },
+      { from: 'you', text: 'Hello!', time: '10:45' },
+    ],
+  },
+  {
+    id: 'team',
+    name: 'Team Support',
+    status: '2 new replies',
+    preview: 'Project Alpha deploy is green ✅',
+    messages: [
+      { from: 'them', text: 'Project Alpha deploy is green ✅', time: '10:10' },
+    ],
+  },
+  {
+    id: 'alpha',
+    name: 'Project Alpha',
+    status: 'Away',
+    preview: 'Meeting at 1pm?',
+    messages: [
+      { from: 'them', text: 'Meeting at 1pm?', time: '09:30' },
+    ],
+  },
+];
+
+let activeChat = chats[0];
+
+function switchView(target) {
+  Object.values(views).forEach((view) => view.classList.remove('active'));
+  views[target].classList.add('active');
+}
+
+function renderChats() {
+  chatListEl.innerHTML = '';
+  chats.forEach((chat) => {
+    const item = document.createElement('button');
+    item.className = `chat-item ${chat.id === activeChat.id ? 'active' : ''}`;
+    item.innerHTML = `
+      <div class="avatar">${chat.name[0]}${chat.name[1] || ''}</div>
+      <div class="chat-meta">
+        <div class="name">${chat.name}</div>
+        <div class="preview">${chat.preview}</div>
+      </div>
+      <div class="status ${chat.status.includes('Active') ? 'online' : ''}">${chat.status}</div>
+    `;
+    item.addEventListener('click', () => {
+      activeChat = chat;
+      renderChats();
+      renderMessages();
+    });
+    chatListEl.appendChild(item);
+  });
+}
+
+function renderMessages() {
+  chatNameEl.textContent = activeChat.name;
+  chatStatusEl.textContent = activeChat.status;
+  messageListEl.innerHTML = '';
+  activeChat.messages.slice().reverse().forEach((msg) => {
+    const bubble = document.createElement('div');
+    bubble.className = `bubble ${msg.from}`;
+    bubble.innerHTML = `<div>${msg.text}</div><div class="timestamp">${msg.time}</div>`;
+    messageListEl.appendChild(bubble);
+  });
+  messageListEl.scrollTop = messageListEl.scrollHeight;
+}
+
+function addMessage(text) {
+  const now = new Date();
+  const time = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  activeChat.messages.push({ from: 'you', text, time });
+  activeChat.preview = text;
+  activeChat.status = 'Active now';
+  renderChats();
+  renderMessages();
+}
+
+// Event wiring
+const loginForm = document.getElementById('login-form');
+loginForm.addEventListener('submit', (e) => {
+  e.preventDefault();
+  switchView('chat');
+  renderChats();
+  renderMessages();
+});
+
+const messageForm = document.getElementById('message-form');
+messageForm.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const text = document.getElementById('message-text').value.trim();
+  if (!text) return;
+  document.getElementById('message-text').value = '';
+  addMessage(text);
+});
+
+// Profile interactions
+const profileForm = document.getElementById('profile-form');
+profileForm.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const name = document.getElementById('profile-name').value.trim();
+  const status = document.getElementById('profile-status').value;
+  const about = document.getElementById('profile-about').value;
+  document.querySelector('.user-block .name').textContent = name || 'You';
+  document.querySelector('.user-block .status').textContent = status;
+  document.querySelector('.user-block .avatar').textContent = name.slice(0, 2) || 'YY';
+  document.querySelector('.profile-header .name').textContent = name || 'You';
+  document.querySelector('.profile-header .status').textContent = status;
+  document.querySelector('.profile-header .avatar').textContent = name.slice(0, 2) || 'YY';
+  localStorage.setItem('profile', JSON.stringify({ name, status, about }));
+  switchView('chat');
+});
+
+document.getElementById('cancel-profile').addEventListener('click', () => switchView('chat'));
+document.getElementById('back-to-chat').addEventListener('click', () => switchView('chat'));
+document.getElementById('open-profile').addEventListener('click', () => switchView('profile'));
+
+document.getElementById('back-button').addEventListener('click', () => switchView('chat'));
+
+document.getElementById('change-photo').addEventListener('click', () => {
+  alert('Photo upload is stubbed in this prototype.');
+});
+
+document.getElementById('forgot').addEventListener('click', (e) => {
+  e.preventDefault();
+  alert('Password reset flow is stubbed in this prototype.');
+});
+
+// Restore saved profile if available
+const savedProfile = localStorage.getItem('profile');
+if (savedProfile) {
+  const { name, status, about } = JSON.parse(savedProfile);
+  document.getElementById('profile-name').value = name;
+  document.getElementById('profile-status').value = status;
+  document.getElementById('profile-about').value = about;
+}
+
+renderChats();
+renderMessages();

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Chat Prototype</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div id="app">
+    <section id="login" class="view active">
+      <div class="card login-card">
+        <div class="logo">💬</div>
+        <h1>Log In</h1>
+        <form id="login-form">
+          <label class="field">
+            <span>Email</span>
+            <input type="email" id="email" placeholder="you@example.com" required />
+          </label>
+          <label class="field">
+            <span>Password</span>
+            <input type="password" id="password" placeholder="••••••••" required />
+          </label>
+          <button type="submit" class="primary">Log In</button>
+          <a class="link" href="#" id="forgot">Forgot password?</a>
+        </form>
+      </div>
+    </section>
+
+    <section id="chat" class="view">
+      <div class="layout">
+        <aside class="sidebar">
+          <div class="user-block">
+            <div class="avatar large">JM</div>
+            <div>
+              <div class="name">John Martinez</div>
+              <div class="status online">Online</div>
+            </div>
+          </div>
+          <div class="chats" id="chat-list">
+            <!-- Chat items injected here -->
+          </div>
+          <div class="sidebar-footer">
+            <button class="ghost" data-action="settings">⚙️ Settings</button>
+            <button class="ghost" data-action="profile" id="open-profile">👤 Profile</button>
+          </div>
+        </aside>
+        <main class="chat-panel">
+          <header class="chat-header">
+            <button class="icon back" id="back-button">←</button>
+            <div>
+              <div class="name" id="chat-name">General Chat</div>
+              <div class="status online" id="chat-status">Active now</div>
+            </div>
+            <button class="icon">⋮</button>
+          </header>
+          <div class="messages" id="message-list">
+            <!-- Messages injected here -->
+          </div>
+          <form class="message-input" id="message-form">
+            <button type="button" class="icon">😊</button>
+            <button type="button" class="icon">📎</button>
+            <input type="text" id="message-text" placeholder="Type your message..." autocomplete="off" />
+            <button type="submit" class="primary">Send ▶</button>
+          </form>
+        </main>
+      </div>
+    </section>
+
+    <section id="profile" class="view">
+      <div class="profile-card">
+        <button class="icon back" id="back-to-chat">← Back to chat</button>
+        <h1>User Profile</h1>
+        <div class="profile-header">
+          <div class="avatar huge">JM</div>
+          <div>
+            <div class="name">John Martinez</div>
+            <div class="status online">Online</div>
+            <button class="ghost small" id="change-photo">Change photo</button>
+          </div>
+        </div>
+        <form id="profile-form" class="profile-form">
+          <label class="field">
+            <span>Name</span>
+            <input type="text" id="profile-name" value="John Martinez" />
+          </label>
+          <label class="field">
+            <span>Email (read-only)</span>
+            <input type="email" value="john@example.com" disabled />
+          </label>
+          <label class="field">
+            <span>Status</span>
+            <select id="profile-status">
+              <option>Online</option>
+              <option>Away</option>
+              <option>Do Not Disturb</option>
+            </select>
+          </label>
+          <label class="field">
+            <span>About</span>
+            <textarea id="profile-about">Enthusiastic developer, loves working with chatbots.</textarea>
+          </label>
+          <div class="preferences">
+            <label class="toggle">
+              <input type="checkbox" id="pref-dark" checked />
+              <span>Dark Mode</span>
+            </label>
+            <label class="toggle">
+              <input type="checkbox" id="pref-notify" checked />
+              <span>Notifications</span>
+            </label>
+          </div>
+          <div class="profile-actions">
+            <button type="button" class="ghost" id="cancel-profile">Cancel</button>
+            <button type="submit" class="primary">Save changes</button>
+          </div>
+        </form>
+      </div>
+    </section>
+  </div>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,0 +1,366 @@
+:root {
+  --bg: #f6f7fb;
+  --card: #ffffff;
+  --primary: #4f46e5;
+  --text: #0f172a;
+  --muted: #64748b;
+  --border: #e2e8f0;
+  --shadow: 0 20px 50px rgba(15, 23, 42, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+#app {
+  min-height: 100vh;
+}
+
+.view {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+}
+
+.view.active {
+  display: flex;
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 32px;
+  width: min(420px, 90vw);
+  box-shadow: var(--shadow);
+}
+
+.login-card h1 {
+  margin: 0 0 16px;
+  text-align: center;
+}
+
+.logo {
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  display: grid;
+  place-items: center;
+  font-size: 24px;
+  margin: 0 auto 16px;
+  background: #eef2ff;
+  color: var(--primary);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 16px;
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.field input,
+.field select,
+.field textarea {
+  width: 100%;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  font-size: 14px;
+}
+
+.field textarea {
+  min-height: 96px;
+  resize: vertical;
+}
+
+button {
+  cursor: pointer;
+  font: inherit;
+}
+
+.primary {
+  background: var(--primary);
+  color: white;
+  border: none;
+  border-radius: 10px;
+  padding: 12px 16px;
+  font-weight: 600;
+  box-shadow: 0 8px 20px rgba(79, 70, 229, 0.25);
+}
+
+.ghost {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 12px;
+  color: var(--text);
+}
+
+.ghost.small {
+  padding: 8px 10px;
+  font-size: 12px;
+}
+
+.icon {
+  border: 1px solid var(--border);
+  background: white;
+  border-radius: 12px;
+  padding: 10px 12px;
+  color: var(--text);
+}
+
+.icon.back {
+  display: none;
+}
+
+.link {
+  display: block;
+  text-align: center;
+  margin-top: 8px;
+  color: var(--primary);
+  text-decoration: none;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 24px;
+  width: min(1200px, 95vw);
+  height: 85vh;
+}
+
+.sidebar {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: var(--shadow);
+}
+
+.user-block {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.avatar {
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #818cf8, #a855f7);
+  color: white;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+}
+
+.avatar.large { width: 56px; height: 56px; }
+.avatar.huge { width: 96px; height: 96px; border-radius: 24px; font-size: 28px; }
+
+.name { font-weight: 700; }
+
+.status {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.status.online::before {
+  content: '';
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  background: #22c55e;
+  border-radius: 999px;
+  margin-right: 6px;
+}
+
+.chats {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.chat-item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 10px;
+  align-items: center;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: #f8fafc;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.chat-item.active {
+  border-color: var(--primary);
+  background: #eef2ff;
+}
+
+.chat-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.chat-meta .preview {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.sidebar-footer {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.chat-panel {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 16px;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 12px;
+  box-shadow: var(--shadow);
+}
+
+.chat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.messages {
+  overflow-y: auto;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
+  border-radius: 12px;
+  border: 1px solid var(--border);
+}
+
+.bubble {
+  max-width: 70%;
+  padding: 10px 12px;
+  border-radius: 14px;
+  position: relative;
+  color: #0f172a;
+  display: inline-block;
+}
+
+.bubble.you {
+  background: #4f46e5;
+  color: white;
+  align-self: flex-end;
+}
+
+.bubble.them {
+  background: white;
+  border: 1px solid var(--border);
+}
+
+.timestamp {
+  font-size: 12px;
+  color: var(--muted);
+  margin-top: 4px;
+}
+
+.message-input {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.message-input input {
+  border: none;
+  background: transparent;
+  font-size: 14px;
+}
+
+.message-input input:focus { outline: none; }
+
+.profile-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 24px;
+  width: min(800px, 95vw);
+  box-shadow: var(--shadow);
+}
+
+.profile-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin: 12px 0 20px;
+}
+
+.profile-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.preferences {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text);
+}
+
+.profile-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+@media (max-width: 900px) {
+  .layout {
+    grid-template-columns: 1fr;
+    height: auto;
+  }
+
+  .sidebar {
+    display: none;
+  }
+
+  .icon.back {
+    display: inline-flex;
+  }
+
+  .chat-panel {
+    height: 80vh;
+  }
+}


### PR DESCRIPTION
## Summary
- add dependency-free HTML/CSS/JS prototype for login → chat → profile flows under web/
- style chat layout with sidebar, message bubbles, composer, and responsive tweaks
- document how to launch the prototype from the repository

## Testing
- not run (static prototype)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bf3163f04832c83e6e8a8b59b1156)